### PR TITLE
Fixed : Remove beans in list is not reflected to Angular client API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "angular": "^1.6.0",
     "dolphin-platform-js": "^0.8.11",
-    "core.js": "^2.4.1",
-    "bootstrap": "^3.3.7"
+    "core.js": "^2.4.1"
   }
 }

--- a/src/dolphin-platform-angular.js
+++ b/src/dolphin-platform-angular.js
@@ -129,7 +129,7 @@ angular.module('DolphinPlatform').factory('dolphinBinding', ['$rootScope', '$tim
 
             $log.debug('Array update for property ' + propertyName + ' starting at index ' + index + ' with ' + JSON.stringify(newElements));
 
-            if (typeof newElements === 'undefined') {
+            if (typeof newElements === 'undefined' || newElements.length === 0) {
                 array.splice(index, count);
                 $rootScope.applyInAngular();
             } else {


### PR DESCRIPTION
- newElements is an array - see ClassRepository -> spliceListEntry
- Add check for empty array for new element
- Removed unused bootstrap entry from bower